### PR TITLE
Improve CancellationToken Support

### DIFF
--- a/Mistral.SDK.Tests/ChatClient.cs
+++ b/Mistral.SDK.Tests/ChatClient.cs
@@ -16,7 +16,7 @@ namespace Mistral.SDK.Tests
             {
                 new(ChatRole.System, "You are an expert at writing sonnets."),
                 new(ChatRole.User, "Write me a sonnet about the Statue of Liberty.")
-            }, new() { ModelId = ModelDefinitions.OpenMistral7b });
+            }, new() { ModelId = ModelDefinitions.OpenMistral7b }).ConfigureAwait(false);
 
             Assert.IsTrue(!string.IsNullOrEmpty(response.Message.Text));
         }
@@ -35,7 +35,7 @@ namespace Mistral.SDK.Tests
             {
                 new(ChatRole.System, "You are an expert at writing Json."),
                 new(ChatRole.User, "Write me a simple 'hello world' statement in a json object with a single 'result' key.")
-            }, new() { ModelId = ModelDefinitions.MistralLarge, ResponseFormat = ChatResponseFormat.Json });
+            }, new() { ModelId = ModelDefinitions.MistralLarge, ResponseFormat = ChatResponseFormat.Json }).ConfigureAwait(false);
 
             Assert.IsTrue(!string.IsNullOrEmpty(response.Message.Text));
 
@@ -53,7 +53,7 @@ namespace Mistral.SDK.Tests
                 {
                     new(ChatRole.System, "You are an expert at writing Json."),
                     new(ChatRole.User, "Write me a simple 'hello world' statement in a json object with a single 'result' key.")
-                }, new() { ModelId = ModelDefinitions.MistralLarge, ResponseFormat = ChatResponseFormat.Json }))
+                }, new() { ModelId = ModelDefinitions.MistralLarge, ResponseFormat = ChatResponseFormat.Json }).ConfigureAwait(false))
             {
                 sb.Append(update);
             }
@@ -81,7 +81,7 @@ namespace Mistral.SDK.Tests
                 {
                     ["SafePrompt"] = true,
                 },
-            });
+            }).ConfigureAwait(false);
 
             Assert.IsTrue(!string.IsNullOrEmpty(response.Message.Text));
         }

--- a/Mistral.SDK.Tests/Completions.cs
+++ b/Mistral.SDK.Tests/Completions.cs
@@ -17,7 +17,7 @@ namespace Mistral.SDK.Tests
                 new ChatMessage(ChatMessage.RoleEnum.System, "You are an expert at writing sonnets."),
                 new ChatMessage(ChatMessage.RoleEnum.User, "Write me a sonnet about the Statue of Liberty.")
             });
-            var response = await client.Completions.GetCompletionAsync(request);
+            var response = await client.Completions.GetCompletionAsync(request).ConfigureAwait(false);
             
         }
         [TestMethod]
@@ -29,7 +29,7 @@ namespace Mistral.SDK.Tests
                 new ChatMessage(ChatMessage.RoleEnum.System, "You are an expert at writing sonnets."),
                 new ChatMessage(ChatMessage.RoleEnum.User, "Write me a sonnet about the Statue of Liberty.")
             });
-            var response = await client.Completions.GetCompletionAsync(request);
+            var response = await client.Completions.GetCompletionAsync(request).ConfigureAwait(false);
 
         }
         [TestMethod]
@@ -41,7 +41,7 @@ namespace Mistral.SDK.Tests
                 new ChatMessage(ChatMessage.RoleEnum.System, "You are an expert at writing sonnets."),
                 new ChatMessage(ChatMessage.RoleEnum.User, "Write me a sonnet about the Statue of Liberty.")
             });
-            var response = await client.Completions.GetCompletionAsync(request);
+            var response = await client.Completions.GetCompletionAsync(request).ConfigureAwait(false);
 
         }
         [TestMethod]
@@ -53,7 +53,7 @@ namespace Mistral.SDK.Tests
                 new ChatMessage(ChatMessage.RoleEnum.System, "You are an expert at writing sonnets."),
                 new ChatMessage(ChatMessage.RoleEnum.User, "Write me a sonnet about the Statue of Liberty.")
             });
-            var response = await client.Completions.GetCompletionAsync(request);
+            var response = await client.Completions.GetCompletionAsync(request).ConfigureAwait(false);
 
         }
         [TestMethod]
@@ -65,7 +65,7 @@ namespace Mistral.SDK.Tests
                 new ChatMessage(ChatMessage.RoleEnum.System, "You are an expert at writing sonnets."),
                 new ChatMessage(ChatMessage.RoleEnum.User, "Write me a sonnet about the Statue of Liberty.")
             });
-            var response = await client.Completions.GetCompletionAsync(request);
+            var response = await client.Completions.GetCompletionAsync(request).ConfigureAwait(false);
 
         }
 
@@ -86,7 +86,7 @@ namespace Mistral.SDK.Tests
             {
                 Type = ResponseFormat.ResponseFormatEnum.JSON
             });
-            var response = await client.Completions.GetCompletionAsync(request);
+            var response = await client.Completions.GetCompletionAsync(request).ConfigureAwait(false);
             //parse json
             var result = JsonSerializer.Deserialize<JsonResult>(response.Choices.First().Message.Content);
             Assert.IsNotNull(result);
@@ -105,7 +105,7 @@ namespace Mistral.SDK.Tests
                 Type = ResponseFormat.ResponseFormatEnum.JSON
             });
             var response = string.Empty;
-            await foreach (var res in client.Completions.StreamCompletionAsync(request))
+            await foreach (var res in client.Completions.StreamCompletionAsync(request).ConfigureAwait(false))
             {
                 response += res.Choices.First().Delta.Content;
             }
@@ -139,7 +139,7 @@ namespace Mistral.SDK.Tests
                 topP: 1, 
                 //optional - defaults to null
                 randomSeed: 32);
-            var response = await client.Completions.GetCompletionAsync(request);
+            var response = await client.Completions.GetCompletionAsync(request).ConfigureAwait(false);
 
         }
 
@@ -157,7 +157,7 @@ namespace Mistral.SDK.Tests
                     "Write me a sonnet about the Statue of Liberty.")
             });
             var results = new List<ChatCompletionResponse>();
-            await foreach (var res in client.Completions.StreamCompletionAsync(request))
+            await foreach (var res in client.Completions.StreamCompletionAsync(request).ConfigureAwait(false))
             {
                 results.Add(res);
                 Debug.Write(res.Choices.First().Delta.Content);
@@ -175,7 +175,7 @@ namespace Mistral.SDK.Tests
                 new ChatMessage(ChatMessage.RoleEnum.User, "Write me a sonnet about the Statue of Liberty.")
             }, safePrompt: true);
             var results = new List<ChatCompletionResponse>();
-            await foreach (var res in client.Completions.StreamCompletionAsync(request))
+            await foreach (var res in client.Completions.StreamCompletionAsync(request).ConfigureAwait(false))
             {
                 results.Add(res);
                 Debug.Write(res.Choices.First().Delta.Content);

--- a/Mistral.SDK.Tests/EmbeddingGenerator.cs
+++ b/Mistral.SDK.Tests/EmbeddingGenerator.cs
@@ -9,7 +9,7 @@ namespace Mistral.SDK.Tests
         public async Task TestMistralEmbeddingsGenerator()
         {
             IEmbeddingGenerator<string, Embedding<float>> client = new MistralClient().Embeddings;
-            var response = await client.GenerateEmbeddingVectorAsync("hello world", new() { ModelId = ModelDefinitions.MistralEmbed });
+            var response = await client.GenerateEmbeddingVectorAsync("hello world", new() { ModelId = ModelDefinitions.MistralEmbed }).ConfigureAwait(false);
             Assert.IsTrue(!response.IsEmpty);
         }
     }

--- a/Mistral.SDK.Tests/Embeddings.cs
+++ b/Mistral.SDK.Tests/Embeddings.cs
@@ -18,7 +18,7 @@ namespace Mistral.SDK.Tests
                 ModelDefinitions.MistralEmbed, 
                 new List<string>() { "Hello world" }, 
                 EmbeddingRequest.EncodingFormatEnum.Float);
-            var response = await client.Embeddings.GetEmbeddingsAsync(request);
+            var response = await client.Embeddings.GetEmbeddingsAsync(request).ConfigureAwait(false);
             Assert.IsNotNull(response);
         }
     }

--- a/Mistral.SDK.Tests/Models.cs
+++ b/Mistral.SDK.Tests/Models.cs
@@ -14,7 +14,7 @@ namespace Mistral.SDK.Tests
         {
             var client = new MistralClient();
             
-            var response = await client.Models.GetModelsAsync();
+            var response = await client.Models.GetModelsAsync().ConfigureAwait(false);
             Assert.IsNotNull(response);
         }
     }

--- a/Mistral.SDK.Tests/Parallel.cs
+++ b/Mistral.SDK.Tests/Parallel.cs
@@ -25,7 +25,7 @@ public class Parallel
                 new ChatMessage(ChatMessage.RoleEnum.System, "You are an expert at writing sonnets."),
                 new ChatMessage(ChatMessage.RoleEnum.User, "Write me a sonnet about the Statue of Liberty.")
             });
-            var response = await client.Completions.GetCompletionAsync(request);
+            var response = await client.Completions.GetCompletionAsync(request).ConfigureAwait(false);
         });
 
     }

--- a/Mistral.SDK/Embeddings/EmbeddingsEndpoint.cs
+++ b/Mistral.SDK/Embeddings/EmbeddingsEndpoint.cs
@@ -28,7 +28,12 @@ namespace Mistral.SDK.Embeddings
         public async Task<EmbeddingResponse> GetEmbeddingsAsync(EmbeddingRequest request, CancellationToken cancellationToken = default)
         {
             var response = await HttpRequestRaw(Url, HttpMethod.Post, request, cancellationToken: cancellationToken).ConfigureAwait(false);
+            
+#if NET8_0_OR_GREATER
+            string resultAsString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
             string resultAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
 
             var res = await JsonSerializer.DeserializeAsync<EmbeddingResponse>(
                 new MemoryStream(Encoding.UTF8.GetBytes(resultAsString)), cancellationToken: cancellationToken)

--- a/Mistral.SDK/Embeddings/EmbeddingsEndpoint.cs
+++ b/Mistral.SDK/Embeddings/EmbeddingsEndpoint.cs
@@ -25,13 +25,14 @@ namespace Mistral.SDK.Embeddings
         /// <summary>
         /// Makes a POST call to the Embeddings API.
         /// </summary>
-        public async Task<EmbeddingResponse> GetEmbeddingsAsync(EmbeddingRequest request)
+        public async Task<EmbeddingResponse> GetEmbeddingsAsync(EmbeddingRequest request, CancellationToken cancellationToken = default)
         {
-            var response = await HttpRequestRaw(Url, HttpMethod.Post, request);
-            string resultAsString = await response.Content.ReadAsStringAsync();
+            var response = await HttpRequestRaw(Url, HttpMethod.Post, request, cancellationToken: cancellationToken).ConfigureAwait(false);
+            string resultAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var res = await JsonSerializer.DeserializeAsync<EmbeddingResponse>(
-                new MemoryStream(Encoding.UTF8.GetBytes(resultAsString)));
+                new MemoryStream(Encoding.UTF8.GetBytes(resultAsString)), cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
 
             return res;
         }
@@ -44,7 +45,7 @@ namespace Mistral.SDK.Embeddings
                 input: values.ToList(),
                 encodingFormat: EmbeddingRequest.EncodingFormatEnum.Float);
 
-            var response = await GetEmbeddingsAsync(request).ConfigureAwait(false);
+            var response = await GetEmbeddingsAsync(request, cancellationToken).ConfigureAwait(false);
 
             var now = DateTime.UtcNow;
             var embeddings = new GeneratedEmbeddings<Embedding<float>>();

--- a/Mistral.SDK/Models/ModelsEndpoint.cs
+++ b/Mistral.SDK/Models/ModelsEndpoint.cs
@@ -26,7 +26,12 @@ namespace Mistral.SDK.Models
         public async Task<ModelList> GetModelsAsync(CancellationToken cancellationToken = default)
         {
             var response = await HttpRequestRaw(Url, HttpMethod.Get, cancellationToken: cancellationToken).ConfigureAwait(false);
+            
+#if NET8_0_OR_GREATER
+            string resultAsString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
             string resultAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
 
             var res = await JsonSerializer.DeserializeAsync<ModelList>(
                 new MemoryStream(Encoding.UTF8.GetBytes(resultAsString)), cancellationToken: cancellationToken)

--- a/Mistral.SDK/Models/ModelsEndpoint.cs
+++ b/Mistral.SDK/Models/ModelsEndpoint.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Mistral.SDK.DTOs;
 
@@ -22,13 +23,14 @@ namespace Mistral.SDK.Models
         /// <summary>
         /// Makes a GET call to the Models API.
         /// </summary>
-        public async Task<ModelList> GetModelsAsync()
+        public async Task<ModelList> GetModelsAsync(CancellationToken cancellationToken = default)
         {
-            var response = await HttpRequestRaw(Url, HttpMethod.Get);
-            string resultAsString = await response.Content.ReadAsStringAsync();
+            var response = await HttpRequestRaw(Url, HttpMethod.Get, cancellationToken: cancellationToken).ConfigureAwait(false);
+            string resultAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var res = await JsonSerializer.DeserializeAsync<ModelList>(
-                new MemoryStream(Encoding.UTF8.GetBytes(resultAsString)));
+                new MemoryStream(Encoding.UTF8.GetBytes(resultAsString)), cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
 
             return res;
         }


### PR DESCRIPTION
Currently there is hardly any cancellation behavour. Longrunning streaming operations can't be aborted.  
This pull request aims to include the passing of the outside `CancellationToken`s.  
As a sideeffect I added ConfigureAwait(false) to all awaiting operations which is generally recommended for agnostic library code.