### PR TITLE
Fix deserialization of reasoning responses

### DIFF
--- a/Mistral.SDK.Tests/ContentConverterTests.cs
+++ b/Mistral.SDK.Tests/ContentConverterTests.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using Mistral.SDK.DTOs;
+
+namespace Mistral.SDK.Tests
+{
+    [TestClass]
+    public class ContentConverterTests
+    {
+        [TestMethod]
+        public void TestContentConverterWithStringContent()
+        {
+            // Regular model response with simple string content
+            string json = @"{
+                ""id"": ""test123"",
+                ""object"": ""chat.completion"",
+                ""created"": 1234567890,
+                ""model"": ""mistral-small-2506"",
+                ""choices"": [
+                    {
+                        ""index"": 0,
+                        ""message"": {
+                            ""role"": ""assistant"",
+                            ""content"": ""This is a simple string response.""
+                        },
+                        ""finish_reason"": ""stop""
+                    }
+                ],
+                ""usage"": {
+                    ""prompt_tokens"": 10,
+                    ""completion_tokens"": 20,
+                    ""total_tokens"": 30
+                }
+            }";
+
+            var response = JsonSerializer.Deserialize<ChatCompletionResponse>(json, MistralClient.JsonSerializationOptions);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.Choices);
+            Assert.AreEqual(1, response.Choices.Count);
+            Assert.IsNotNull(response.Choices[0].Message);
+            Assert.AreEqual("This is a simple string response.", response.Choices[0].Message.Content);
+        }
+
+        [TestMethod]
+        public void TestContentConverterWithArrayContent()
+        {
+            // Thinking model response with array content (based on magistral-medium-2509)
+            string json = @"{
+                ""id"": ""25b5475d6e2c48c9a9d80a48a4f302a3"",
+                ""object"": ""chat.completion"",
+                ""created"": 1761293297,
+                ""model"": ""magistral-medium-latest"",
+                ""choices"": [
+                    {
+                        ""index"": 0,
+                        ""message"": {
+                            ""role"": ""assistant"",
+                            ""content"": [
+                                {
+                                    ""type"": ""thinking"",
+                                    ""thinking"": [
+                                        {
+                                            ""type"": ""text"",
+                                            ""text"": ""Let me think about this...""
+                                        }
+                                    ]
+                                },
+                                {
+                                    ""type"": ""text"",
+                                    ""text"": ""Here is my response.""
+                                }
+                            ]
+                        },
+                        ""finish_reason"": ""stop""
+                    }
+                ],
+                ""usage"": {
+                    ""prompt_tokens"": 10,
+                    ""completion_tokens"": 1360,
+                    ""total_tokens"": 1370
+                }
+            }";
+
+            var response = JsonSerializer.Deserialize<ChatCompletionResponse>(json, MistralClient.JsonSerializationOptions);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.Choices);
+            Assert.AreEqual(1, response.Choices.Count);
+            Assert.IsNotNull(response.Choices[0].Message);
+            Assert.IsNotNull(response.Choices[0].Message.Content);
+
+            // Content should be a JSON string containing the array
+            Assert.IsTrue(response.Choices[0].Message.Content.Contains("thinking"));
+            Assert.IsTrue(response.Choices[0].Message.Content.Contains("Here is my response."));
+
+            // Verify it's valid JSON
+            var contentArray = JsonSerializer.Deserialize<JsonElement>(response.Choices[0].Message.Content);
+            Assert.AreEqual(JsonValueKind.Array, contentArray.ValueKind);
+        }
+
+        [TestMethod]
+        public void TestContentConverterWithNullContent()
+        {
+            // Response with null content
+            string json = @"{
+                ""id"": ""test123"",
+                ""object"": ""chat.completion"",
+                ""created"": 1234567890,
+                ""model"": ""mistral-small-2506"",
+                ""choices"": [
+                    {
+                        ""index"": 0,
+                        ""message"": {
+                            ""role"": ""assistant"",
+                            ""content"": null
+                        },
+                        ""finish_reason"": ""stop""
+                    }
+                ],
+                ""usage"": {
+                    ""prompt_tokens"": 10,
+                    ""completion_tokens"": 0,
+                    ""total_tokens"": 10
+                }
+            }";
+
+            var response = JsonSerializer.Deserialize<ChatCompletionResponse>(json, MistralClient.JsonSerializationOptions);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.Choices);
+            Assert.AreEqual(1, response.Choices.Count);
+            Assert.IsNotNull(response.Choices[0].Message);
+            Assert.IsNull(response.Choices[0].Message.Content);
+        }
+
+        [TestMethod]
+        public void TestContentConverterRoundTrip()
+        {
+            // Create a message with string content
+            var message = new ChatMessage
+            {
+                Role = ChatMessage.RoleEnum.Assistant,
+                Content = "Test content"
+            };
+
+            // Serialize to JSON
+            var json = JsonSerializer.Serialize(message, MistralClient.JsonSerializationOptions);
+
+            // Deserialize back
+            var deserialized = JsonSerializer.Deserialize<ChatMessage>(json, MistralClient.JsonSerializationOptions);
+
+            Assert.IsNotNull(deserialized);
+            Assert.AreEqual("Test content", deserialized.Content);
+            Assert.AreEqual(ChatMessage.RoleEnum.Assistant, deserialized.Role);
+        }
+
+        [TestMethod]
+        public void TestContentConverterStreamingWithArrayContent()
+        {
+            // Streaming response delta with array content
+            string json = @"{
+                ""id"": ""test123"",
+                ""object"": ""chat.completion.chunk"",
+                ""created"": 1234567890,
+                ""model"": ""magistral-medium-latest"",
+                ""choices"": [
+                    {
+                        ""index"": 0,
+                        ""delta"": {
+                            ""role"": ""assistant"",
+                            ""content"": [
+                                {
+                                    ""type"": ""text"",
+                                    ""text"": ""Streaming text...""
+                                }
+                            ]
+                        },
+                        ""finish_reason"": null
+                    }
+                ]
+            }";
+
+            var response = JsonSerializer.Deserialize<ChatCompletionResponse>(json, MistralClient.JsonSerializationOptions);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.Choices);
+            Assert.AreEqual(1, response.Choices.Count);
+            Assert.IsNotNull(response.Choices[0].Delta);
+            Assert.IsNotNull(response.Choices[0].Delta.Content);
+            Assert.IsTrue(response.Choices[0].Delta.Content.Contains("Streaming text..."));
+        }
+    }
+}

--- a/Mistral.SDK/Converters/MessageContentConverter.cs
+++ b/Mistral.SDK/Converters/MessageContentConverter.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Mistral.SDK.Converters
+{
+    /// <summary>
+    /// Custom JSON converter for message content that handles both string and array formats.
+    /// Mistral thinking models return content as an array of content objects, while regular models return a simple string.
+    /// This converter serializes array content to a JSON string to maintain backward compatibility.
+    /// </summary>
+    public class MessageContentConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.String:
+                    // Regular content is a simple string
+                    return reader.GetString();
+
+                case JsonTokenType.StartArray:
+                    // Thinking model content is an array - serialize it to JSON string
+                    using (JsonDocument doc = JsonDocument.ParseValue(ref reader))
+                    {
+                        return JsonSerializer.Serialize(doc.RootElement, options);
+                    }
+
+                case JsonTokenType.Null:
+                    return null;
+
+                default:
+                    throw new JsonException($"Unexpected token type '{reader.TokenType}' when parsing message content. Expected String or StartArray.");
+            }
+        }
+        
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(value);
+            }
+        }
+    }
+}

--- a/Mistral.SDK/DTOs/ChatMessage.cs
+++ b/Mistral.SDK/DTOs/ChatMessage.cs
@@ -79,6 +79,7 @@ namespace Mistral.SDK.DTOs
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
+        [JsonConverter(typeof(MessageContentConverter))]
         public string Content { get; set; }
 
         [JsonPropertyName("tool_calls")]

--- a/Mistral.SDK/EndpointBase.cs
+++ b/Mistral.SDK/EndpointBase.cs
@@ -94,7 +94,9 @@ namespace Mistral.SDK
 #endif
 
             var res = await JsonSerializer.DeserializeAsync<ChatCompletionResponse>(
-                new MemoryStream(Encoding.UTF8.GetBytes(resultAsString)), cancellationToken: cancellationToken)
+                new MemoryStream(Encoding.UTF8.GetBytes(resultAsString)),
+                MistralClient.JsonSerializationOptions,
+                cancellationToken: cancellationToken)
                 .ConfigureAwait(false); 
 
             return res;
@@ -200,14 +202,18 @@ namespace Mistral.SDK
                     else if (currentEvent.EventType == null)
                     {
                         var res = await JsonSerializer.DeserializeAsync<ChatCompletionResponse>(
-                            new MemoryStream(Encoding.UTF8.GetBytes(currentEvent.Data)), cancellationToken: cancellationToken)
+                            new MemoryStream(Encoding.UTF8.GetBytes(currentEvent.Data)),
+                            MistralClient.JsonSerializationOptions,
+                            cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                         yield return res;
                     }
                     else if (currentEvent.EventType != null)
                     {
                         var res = await JsonSerializer.DeserializeAsync<ErrorResponse>(
-                            new MemoryStream(Encoding.UTF8.GetBytes(currentEvent.Data)), cancellationToken: cancellationToken)
+                            new MemoryStream(Encoding.UTF8.GetBytes(currentEvent.Data)),
+                            MistralClient.JsonSerializationOptions,
+                            cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                         throw new Exception(res.Error.Message);
                     }

--- a/Mistral.SDK/MistralClient.cs
+++ b/Mistral.SDK/MistralClient.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json.Serialization;
 using System.Text.Json;
 using Mistral.SDK.Completions;
+using Mistral.SDK.Converters;
 using Mistral.SDK.Embeddings;
 using Mistral.SDK.Models;
 
@@ -53,10 +54,13 @@ namespace Mistral.SDK
             Embeddings = new EmbeddingsEndpoint(this);
         }
 
-        internal static JsonSerializerOptions JsonSerializationOptions { get; } = new()
+        /// <summary>
+        /// JSON serialization options used by the SDK, including custom converters for Mistral-specific types.
+        /// </summary>
+        public static JsonSerializerOptions JsonSerializationOptions { get; } = new()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            Converters = { new JsonStringEnumConverter() },
+            Converters = { new JsonStringEnumConverter(), new MessageContentConverter() },
             ReferenceHandler = ReferenceHandler.IgnoreCycles,
         };
 


### PR DESCRIPTION
Mistral's reasoning models return content as an array of objects instead of a simple string, which was breaking deserialization. This PR fixes that.

Added a custom MessageContentConverter that handles both formats - when it sees an array, it just serializes it to a JSON string so everything keeps working as expected. This mirrors the behavior of Microsoft.SemanticKernel.Connectors.MistralAI.Client. Applied it to all the deserialization paths and added tests to make sure both regular responses and reasoning model responses work correctly.

Closes #31.