### PR TITLE
Add option to generate and use custom structured outputs

### DIFF
--- a/Mistral.SDK.Tests/ChatClient.cs
+++ b/Mistral.SDK.Tests/ChatClient.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
-using Mistral.SDK.Converters;
 
 namespace Mistral.SDK.Tests
 {
@@ -42,6 +41,28 @@ namespace Mistral.SDK.Tests
 
             //parse json
             Assert.IsNotNull(JsonSerializer.Deserialize<JsonResult>(response.Text));
+        }
+
+        [TestMethod]
+        public async Task TestMistralCompletionJsonSchemaMode()
+        {
+            IChatClient client = new MistralClient().Completions;
+
+            var chatResponseFormat = ChatResponseFormat.ForJsonSchema(
+                schema: AIJsonUtilities.CreateJsonSchema(typeof(JsonResult)),
+                schemaName: "JsonResult",
+                schemaDescription: "A simple object with a single 'result' key containing a hello world statement.");
+
+            var result = await client.GetResponseAsync<JsonResult>(
+                messages: new List<ChatMessage>()
+                {
+                    new(ChatRole.System, "You are an expert writing sonnets."),
+                    new(ChatRole.User, "Write me a sonnet about the Statue of Liberty.")
+                },
+                options: new() { ModelId = ModelDefinitions.OpenMistral7b, ResponseFormat = chatResponseFormat },
+                useJsonSchemaResponseFormat: true).ConfigureAwait(false);
+
+            Assert.IsTrue(!string.IsNullOrEmpty(result.Result.result));
         }
 
         [TestMethod]

--- a/Mistral.SDK/Completions/CompletionsEndpoint.ChatClient.cs
+++ b/Mistral.SDK/Completions/CompletionsEndpoint.ChatClient.cs
@@ -256,9 +256,25 @@ namespace Mistral.SDK.Completions
             request.ParallelToolCalls = options?.AllowMultipleToolCalls ?? request.ParallelToolCalls;
             request.RandomSeed ??= (int?)options?.Seed;
 
-            if (options?.ResponseFormat is ChatResponseFormatJson)
+            if (options?.ResponseFormat is ChatResponseFormatJson chatResponseFormatJson)
             {
-                request.ResponseFormat ??= new ResponseFormat() { Type = ResponseFormat.ResponseFormatEnum.JSON };
+                if (chatResponseFormatJson.Schema != null)
+                {
+                    request.ResponseFormat = new ResponseFormat()
+                    {
+                        Type = ResponseFormat.ResponseFormatEnum.JSON_SCHEMA,
+                        JsonSchema = new ResponseFormatJsonSchema
+                        {
+                            Schema = chatResponseFormatJson.Schema.Value,
+                            Name = chatResponseFormatJson.SchemaName,
+                            Strict = true
+                        }
+                    };
+                }
+                else
+                {
+                    request.ResponseFormat = new ResponseFormat() { Type = ResponseFormat.ResponseFormatEnum.JSON };
+                }
             }
 
             List<Common.Tool> tools = null;
@@ -341,7 +357,7 @@ namespace Mistral.SDK.Completions
         object IChatClient.GetService(Type serviceType, object serviceKey) =>
             serviceKey is not null ? null :
             serviceType == typeof(ChatClientMetadata) ? (_metadata ??= new ChatClientMetadata(nameof(MistralClient), new Uri(Url))) :
-            serviceType?.IsInstanceOfType(this) is true ? this : 
+            serviceType?.IsInstanceOfType(this) is true ? this :
             null;
 
         private ChatClientMetadata _metadata;
@@ -359,5 +375,5 @@ namespace Mistral.SDK.Completions
         }
     }
 
-    
+
 }

--- a/Mistral.SDK/DTOs/ResponseFormat.cs
+++ b/Mistral.SDK/DTOs/ResponseFormat.cs
@@ -1,7 +1,5 @@
 ﻿using Mistral.SDK.Converters;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Mistral.SDK.DTOs
@@ -15,14 +13,46 @@ namespace Mistral.SDK.DTOs
 			/// Enum json for value: json_object
 			/// </summary>
 			[JsonPropertyName("json_object")]
-			JSON = 1
+			JSON = 1,
+			/// <summary>
+			/// Enum json_schema for value: json_schema
+			/// </summary>
+			[JsonPropertyName("json_schema")]
+			JSON_SCHEMA = 2
 		}
 
 		/// <summary>
 		/// The output type
 		/// </summary>
 		[JsonPropertyName("type")]
-		
+
 		public ResponseFormatEnum Type { get; set; }
+
+		/// <summary>
+		/// The JSON Schema for the response (only applicable if type is json_schema)
+		/// </summary>
+		[JsonPropertyName("json_schema")]
+		public ResponseFormatJsonSchema JsonSchema { get; set; }
+	}
+
+	public class ResponseFormatJsonSchema
+	{
+		/// <summary>
+		/// The name of the schema
+		/// </summary>
+		[JsonPropertyName("name")]
+		public string Name { get; set; }
+
+		/// <summary>
+		/// Whether to enforce strict validation against the schema
+		/// </summary>
+		[JsonPropertyName("strict")]
+		public bool Strict { get; set; }
+
+		/// <summary>
+		/// The schema definition
+		/// </summary>
+		[JsonPropertyName("schema")]
+		public JsonElement Schema { get; set; }
 	}
 }


### PR DESCRIPTION
A minimal addition to add support for [Custom Structured Outputs](https://docs.mistral.ai/capabilities/structured_output/custom).

Included a single integration test.
The `IChatClient` API does not seem to support the streaming scenario for custom structured outputs.

Closes #36  