### PR TITLE
Add image & document support to Mistral ChatClient by serializing DataContent as multimodal chunks

### DIFF
--- a/Mistral.SDK/Completions/CompletionsEndpoint.ChatClient.cs
+++ b/Mistral.SDK/Completions/CompletionsEndpoint.ChatClient.cs
@@ -56,7 +56,7 @@ namespace Mistral.SDK.Completions
                     ChatRole role = choice.Delta?.Role switch
                     {
                         DTOs.ChatMessage.RoleEnum.System => ChatRole.System,
-                        DTOs.ChatMessage.RoleEnum.Assistant => ChatRole.User,
+                        DTOs.ChatMessage.RoleEnum.Assistant => ChatRole.Assistant, // formerly (an error or a typo?) ChatRole.User
                         _ => ChatRole.User,
                     };
 
@@ -131,6 +131,7 @@ namespace Mistral.SDK.Completions
             request.Messages.AddRange(chatMessages.SelectMany(m =>
             {
                 return ToChatMessageDTO(m);
+
                 static IEnumerable<DTOs.ChatMessage> ToChatMessageDTO(Microsoft.Extensions.AI.ChatMessage m)
                 {
                     DTOs.ChatMessage.RoleEnum role =
@@ -139,12 +140,38 @@ namespace Mistral.SDK.Completions
                         m.Role == ChatRole.Tool ? DTOs.ChatMessage.RoleEnum.Tool :
                         DTOs.ChatMessage.RoleEnum.User;
 
+                    // We collect all multimodal chunks for this message
+                    List<DTOs.ChatMessageContentChunk>? chunks = null;
+
                     foreach (AIContent content in m.Contents)
                     {
                         switch (content)
                         {
                             case Microsoft.Extensions.AI.TextContent tc:
-                                yield return new DTOs.ChatMessage(role, tc.Text);
+                                (chunks ??= []).Add(new DTOs.ChatMessageContentChunk
+                                {
+                                    Type = "text",
+                                    Text = tc.Text
+                                });
+                                break;
+
+                            case Microsoft.Extensions.AI.DataContent dc:
+                                // DataContent (Uri) -> chunk image_url or document_url, depending on MediaType
+                                string mediaType = dc.MediaType?.ToString() ?? "application/octet-stream";
+                                string dataUrl = string.IsNullOrEmpty(dc.Uri) ?
+                                    // If dc.Uri, we can reconstruct "data:<mime>;base64,..." from dc.Data bytes here.
+                                    $"data:{mediaType};base64,{Convert.ToBase64String(dc.Data.ToArray())}" :
+                                    // But as we should receive a DataContent with a valid Uri & MediaType, this is just a fallback.
+                                    dc.Uri.ToString();
+
+                                bool isImage = mediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+
+                                (chunks ??= []).Add(new DTOs.ChatMessageContentChunk
+                                {
+                                    Type = isImage ? "image_url" : "document_url",
+                                    ImageUrl = isImage ? dataUrl : null,    
+                                    DocumentUrl = !isImage ? dataUrl : null
+                                });
                                 break;
 
                             case Microsoft.Extensions.AI.FunctionCallContent fcc:
@@ -169,6 +196,25 @@ namespace Mistral.SDK.Completions
                             case Microsoft.Extensions.AI.FunctionResultContent frc:
                                 yield return new DTOs.ChatMessage(frc.CallId, frc.CallId, frc.Result?.ToString());
                                 break;
+                        }
+                    }
+
+                    // Send the main message (text or multimodal)
+                    if (chunks is { Count: > 0 })
+                    {
+                        // optimization: if it is only a text chunk, we keep the string format (backward compatible)
+                        if (chunks.Count == 1 && chunks[0].Type == "text")
+                        {
+                            yield return new DTOs.ChatMessage(role, chunks[0].Text ?? string.Empty);
+                        }
+                        else
+                        {
+                            yield return new DTOs.ChatMessage()
+                            {
+                                Role = role,
+                                Content = string.Empty, // kept for compatibility
+                                ContentChunks = chunks  // will be serialized as an array
+                            };
                         }
                     }
                 }
@@ -226,7 +272,10 @@ namespace Mistral.SDK.Completions
 
                     if (i + 1 < next)
                     {
-                        request.Messages[i].Content = string.Join("\n", request.Messages.Skip(i).Take(next - i).Select(m => m.Content));
+                        // (former code) request.Messages[i].Content = string.Join("\n", request.Messages.Skip(i).Take(next - i).Select(m => m.Content));
+                        // When merging consecutive user messages, if one of them has ContentChunks, we merge the chunks.
+                        for (int j = i + 1; j < next; j++)
+                            MergeUserMessages(request.Messages[i], request.Messages[j]);
                         request.Messages.RemoveRange(i + 1, next - (i + 1));
                     }
                 }
@@ -301,6 +350,31 @@ namespace Mistral.SDK.Completions
             }
 
             return request;
+
+            static void MergeUserMessages(DTOs.ChatMessage into, DTOs.ChatMessage other)
+            {
+                // If no multimodal: former logic
+                if ((into.ContentChunks is null || into.ContentChunks.Count == 0) 
+                 && (other.ContentChunks is null || other.ContentChunks.Count == 0))
+                {
+                    into.Content = string.Join("\n", into.Content, other.Content);
+                    return;
+                }
+
+                into.ContentChunks ??= new List<DTOs.ChatMessageContentChunk>();
+
+                // Converts existing text content into chunks if necessary
+                if (!string.IsNullOrEmpty(into.Content) && into.ContentChunks.Count == 0)
+                    into.ContentChunks.Add(new DTOs.ChatMessageContentChunk { Type = "text", Text = into.Content });
+
+                // Adds chunks from other
+                if (other.ContentChunks is { Count: > 0 })
+                    into.ContentChunks.AddRange(other.ContentChunks);
+                else if (!string.IsNullOrEmpty(other.Content))
+                    into.ContentChunks.Add(new DTOs.ChatMessageContentChunk { Type = "text", Text = other.Content });
+
+                into.Content = string.Empty;
+            }
         }
 
         private static List<AIContent> ProcessResponseContent(ChatCompletionResponse response)

--- a/Mistral.SDK/Converters/ChatMessageJsonConverter.cs
+++ b/Mistral.SDK/Converters/ChatMessageJsonConverter.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Mistral.SDK.DTOs;
+
+namespace Mistral.SDK.Converters
+{
+    public sealed class ChatMessageJsonConverter : JsonConverter<ChatMessage>
+    {
+        public override ChatMessage Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using var doc = JsonDocument.ParseValue(ref reader);
+            var root = doc.RootElement;
+
+            var msg = new ChatMessage();
+
+            if (root.TryGetProperty("role", out var roleEl) && roleEl.ValueKind == JsonValueKind.String)
+            {
+                msg.Role = roleEl.GetString() switch
+                {
+                    "system" => ChatMessage.RoleEnum.System,
+                    "user" => ChatMessage.RoleEnum.User,
+                    "assistant" => ChatMessage.RoleEnum.Assistant,
+                    "tool" => ChatMessage.RoleEnum.Tool,
+                    _ => msg.Role
+                };
+            }
+
+            if (root.TryGetProperty("name", out var nameEl) && nameEl.ValueKind == JsonValueKind.String)
+                msg.Name = nameEl.GetString();
+
+            if (root.TryGetProperty("tool_call_id", out var tcidEl) && tcidEl.ValueKind == JsonValueKind.String)
+                msg.ToolCallId = tcidEl.GetString();
+
+            if (root.TryGetProperty("tool_calls", out var toolCallsEl) && toolCallsEl.ValueKind != JsonValueKind.Null)
+                msg.ToolCalls = JsonSerializer.Deserialize<List<ToolCall>>(toolCallsEl.GetRawText(), options);
+
+            if (root.TryGetProperty("content", out var contentEl))
+            {
+                if (contentEl.ValueKind == JsonValueKind.String)
+                {
+                    msg.Content = contentEl.GetString();
+                }
+                else if (contentEl.ValueKind == JsonValueKind.Array)
+                {
+                    msg.ContentChunks = JsonSerializer.Deserialize<List<ChatMessageContentChunk>>(contentEl.GetRawText(), options);
+                    msg.Content ??= string.Empty;
+                }
+            }
+
+            return msg;
+        }
+
+        public override void Write(Utf8JsonWriter writer, ChatMessage value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+
+            if (value.Role is not null)
+            {
+                writer.WriteString("role", value.Role switch
+                {
+                    ChatMessage.RoleEnum.System => "system",
+                    ChatMessage.RoleEnum.User => "user",
+                    ChatMessage.RoleEnum.Assistant => "assistant",
+                    ChatMessage.RoleEnum.Tool => "tool",
+                    _ => "user"
+                });
+            }
+
+            if (!string.IsNullOrEmpty(value.Name))
+                writer.WriteString("name", value.Name);
+
+            if (!string.IsNullOrEmpty(value.ToolCallId))
+                writer.WriteString("tool_call_id", value.ToolCallId);
+
+            if (value.ToolCalls is { Count: > 0 })
+            {
+                writer.WritePropertyName("tool_calls");
+                JsonSerializer.Serialize(writer, value.ToolCalls, options);
+            }
+
+            // Key point: if there are content chunks, we serialize them as an array; otherwise, we serialize the content as a string.
+            writer.WritePropertyName("content");
+            if (value.ContentChunks is { Count: > 0 })
+            {
+                JsonSerializer.Serialize(writer, value.ContentChunks, options);
+            }
+            else
+            {
+                writer.WriteStringValue(value.Content ?? string.Empty);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/Mistral.SDK/Converters/ChatMessageJsonConverter.cs
+++ b/Mistral.SDK/Converters/ChatMessageJsonConverter.cs
@@ -6,6 +6,25 @@ using Mistral.SDK.DTOs;
 
 namespace Mistral.SDK.Converters
 {
+    /// <summary>
+    /// JSON converter for <see cref="DTOs.ChatMessage"/> that supports both the legacy and multimodal
+    /// representations of the <c>content</c> field used by the Mistral Chat Completions API.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Historically, the SDK modeled <c>content</c> as a simple string. Vision / multimodal requests require
+    /// <c>content</c> to be an array of typed chunks (e.g. <c>{"type":"text"}</c>, <c>{"type":"image_url"}</c>).
+    /// This converter keeps backward compatibility by serializing <see cref="DTOs.ChatMessage.Content"/> as a string
+    /// when no chunks are present, and serializing <see cref="DTOs.ChatMessage.ContentChunks"/> as a JSON array otherwise.
+    /// </para>
+    /// <para>
+    /// On deserialization, it accepts both shapes:
+    /// <list type="bullet">
+    ///   <item><description><c>"content": "…"</c></description></item>
+    ///   <item><description><c>"content": [ { … }, { … } ]</c></description></item>
+    /// </list>
+    /// </para>
+    /// </remarks>
     public sealed class ChatMessageJsonConverter : JsonConverter<ChatMessage>
     {
         public override ChatMessage Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/Mistral.SDK/DTOs/ChatMessage.cs
+++ b/Mistral.SDK/DTOs/ChatMessage.cs
@@ -4,6 +4,7 @@ using Mistral.SDK.Converters;
 
 namespace Mistral.SDK.DTOs
 {
+    [JsonConverter(typeof(ChatMessageJsonConverter))]
     public class ChatMessage
     {
         /// <summary>
@@ -75,11 +76,19 @@ namespace Mistral.SDK.DTOs
 
         [JsonPropertyName("name")]
         public string Name { get; set; }
+
         /// <summary>
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
         public string Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of content chunks associated with the chat message.
+        /// </summary>
+        /// <remarks>Not serialized directly (the converter handles this).</remarks>
+        [JsonIgnore]
+        public List<ChatMessageContentChunk>? ContentChunks { get; set; }
 
         [JsonPropertyName("tool_calls")]
         public List<ToolCall> ToolCalls { get; set; }

--- a/Mistral.SDK/DTOs/ChatMessageContentChunk.cs
+++ b/Mistral.SDK/DTOs/ChatMessageContentChunk.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Mistral.SDK.DTOs
+{
+    /// <summary>
+    /// Represents a discrete chunk of content within a chat message, which may be text, an image, or a document.
+    /// </summary>
+    /// <remarks>Use this class to encapsulate a single type of content for a chat message. The specific
+    /// content is determined by the value of the Type property, and only the corresponding content property (Text,
+    /// ImageUrl, or DocumentUrl) should be populated for each instance. 
+    /// See Mistral cookbook: https://docs.mistral.ai/capabilities/vision</remarks>
+    public sealed class ChatMessageContentChunk
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = default!; // "text" | "image_url" | "document_url" ...
+
+        [JsonPropertyName("text")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Text { get; set; }
+
+        [JsonPropertyName("image_url")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ImageUrl { get; set; }
+
+        [JsonPropertyName("document_url")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? DocumentUrl { get; set; }
+    }
+}

--- a/Mistral.SDK/Mistral.SDK.csproj
+++ b/Mistral.SDK/Mistral.SDK.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;.net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;.net8.0;.net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<Authors>Grant Hamm</Authors>


### PR DESCRIPTION
## Context

With `Microsoft.Extensions.AI`, we can send a user message that includes **text + an image** via `DataContent`.
This works with OpenAI (e.g., `gpt-5.2`) but not with `Mistral.SDK`, because `CompletionsEndpoint.ChatClient.CreateRequest()` only serializes message `content` as a **string** and does not handle `DataContent`.

Result: the prompt is sent, but the image is dropped, so vision/image analysis cannot work.

## What this PR does

- Adds support for Mistral multimodal messages (`content: string | chunk[]`) in the ChatClient request payload, matching the format expected by Mistral Vision.
- Converts `Microsoft.Extensions.AI.DataContent` (binary payload) into an `image_url` or `document_url` (PDF...) chunk using a **data URL** (`data:<mime>;base64,...`).
- Keeps backward compatibility: text-only messages still serialize `content` as a plain string.

## Key changes

- Introduce a new DTO: `ChatMessageContentChunk` (e.g., `type=text`, `type=image_url`).
- Extend `ChatMessage` DTO to support `ContentChunks`.
- Add a `JsonConverter` to serialize `content` dynamically as either:
  - a `string` (text-only), or
  - a `chunk[]` array (multimodal).
- Update `CompletionsEndpoint.ChatClient` mapping:
  - `TextContent` -> `{ type: "text", text: "..." }`
  - `DataContent` (`ReadOnlyMemory<byte>`) -> `{ type: "image_url", image_url: "data:...;base64,..." }`
- Fix user-message consolidation logic so consecutive user messages merge `ContentChunks` instead of losing images.
- Also fixed (typo?) streaming role mapping if `assistant` messages were incorrectly mapped.

## Example payload (after)

```json
{
  "role": "user",
  "content": [
    { "type": "text", "text": "Describe this image." },
    { "type": "image_url", "image_url": "data:image/jpeg;base64,..." }
  ]
}
```

## Tested with Mistral vision-capable model (mistral-large-2512).

*   Text-only request (unchanged behavior)
    
*   Text + image request using DataContent (API receives content\[\] and returns an image description)
    
*   Streaming (if applicable)
    

## Notes / Compatibility

*   Non-breaking: text-only flows remain unchanged.
